### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "~5.4",
+        "laravel/framework": "5.4.* || 5.5.*",
         "optimus/distributed-laravel": "~0.1",
         "optimus/bruno": "~3.0",
         "optimus/genie": "~2.0",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.